### PR TITLE
enable config_enableAutoPowerModes for power saving

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -164,7 +164,7 @@
          dozing).  This should be enabled if you have such services and expect apps to
          correctly use them when installed on your device.  Otherwise, keep this disabled
          so that applications can still use their own mechanisms. -->
-    <bool name="config_enableAutoPowerModes">false</bool>
+    <bool name="config_enableAutoPowerModes">true</bool>
 
     <!-- The threshold angle for any motion detection in auto-power save modes.
          In hundreths of a degree. -->


### PR DESCRIPTION
set config_enableAutoPowerModes to true to enable power saving functions like doze and app-standby for prolonged battery life
